### PR TITLE
Add resultset data-format and metadata controls, propagate through server, tests, and SDK source samples

### DIFF
--- a/db/src/main/java/com/synclite/db/DB.java
+++ b/db/src/main/java/com/synclite/db/DB.java
@@ -26,6 +26,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -34,6 +35,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 import io.synclite.logger.*;
 
@@ -129,8 +133,9 @@ public class DB {
 		private Map<String, Object> bufferedRow;
 		private int paginationSize;
 		private long lastUsedMs;
+		final JSONArray columnMetadata;
 
-		private ResultSetPageState(UUID handle, Path dbPath, String requesterPrincipal, Connection connection, Statement statement, ResultSet resultSet, Map<String, Object> bufferedRow, int paginationSize) {
+		private ResultSetPageState(UUID handle, Path dbPath, String requesterPrincipal, Connection connection, Statement statement, ResultSet resultSet, Map<String, Object> bufferedRow, int paginationSize, JSONArray columnMetadata) {
 			this.handle = handle;
 			this.dbPath = dbPath;
 			this.requesterPrincipal = requesterPrincipal;
@@ -140,6 +145,7 @@ public class DB {
 			this.bufferedRow = bufferedRow;
 			this.paginationSize = paginationSize;
 			this.lastUsedMs = System.currentTimeMillis();
+			this.columnMetadata = columnMetadata;
 		}
 
 		private void touch() {
@@ -166,20 +172,50 @@ public class DB {
 		public final List<Map<String, Object>> rows;
 		public final UUID resultsetHandle;
 		public final boolean hasMore;
+		public final JSONArray columnMetadata;
 
-		public ResultSetPage(List<Map<String, Object>> rows, UUID resultsetHandle, boolean hasMore) {
+		public ResultSetPage(List<Map<String, Object>> rows, UUID resultsetHandle, boolean hasMore, JSONArray columnMetadata) {
 			this.rows = rows;
 			this.resultsetHandle = resultsetHandle;
 			this.hasMore = hasMore;
+			this.columnMetadata = columnMetadata;
 		}
 	}
 
 	private static Map<String, Object> readCurrentRow(ResultSet rs, ResultSetMetaData metaData, int columnCount) throws SQLException {
-		Map<String, Object> row = new HashMap<String, Object>();
+		Map<String, Object> row = new LinkedHashMap<String, Object>();
 		for (int i = 1; i <= columnCount; i++) {
 			row.put(metaData.getColumnLabel(i), rs.getObject(i));
 		}
 		return row;
+	}
+
+	static JSONArray extractColumnMetadata(ResultSetMetaData metaData, int columnCount) throws SQLException {
+		JSONArray metadata = new JSONArray();
+		for (int i = 1; i <= columnCount; i++) {
+			JSONObject col = new JSONObject();
+			col.put("name", metaData.getColumnName(i));
+			col.put("label", metaData.getColumnLabel(i));
+			col.put("type", metaData.getColumnType(i));
+			col.put("type-name", metaData.getColumnTypeName(i));
+			col.put("display-size", metaData.getColumnDisplaySize(i));
+			col.put("precision", metaData.getPrecision(i));
+			col.put("scale", metaData.getScale(i));
+			col.put("nullable", metaData.isNullable(i));
+			col.put("auto-increment", metaData.isAutoIncrement(i));
+			col.put("case-sensitive", metaData.isCaseSensitive(i));
+			col.put("searchable", metaData.isSearchable(i));
+			col.put("currency", metaData.isCurrency(i));
+			col.put("signed", metaData.isSigned(i));
+			col.put("read-only", metaData.isReadOnly(i));
+			col.put("writable", metaData.isWritable(i));
+			col.put("catalog-name", metaData.getCatalogName(i));
+			col.put("schema-name", metaData.getSchemaName(i));
+			col.put("table-name", metaData.getTableName(i));
+			col.put("class-name", metaData.getColumnClassName(i));
+			metadata.put(col);
+		}
+		return metadata;
 	}
 
 	private static void closeAndRemoveResultSetHandle(UUID handle) {
@@ -248,6 +284,7 @@ public class DB {
 		List<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
 		ResultSetMetaData metaData = rs.getMetaData();
 		int columnCount = metaData.getColumnCount();
+		JSONArray columnMetadata = extractColumnMetadata(metaData, columnCount);
 
 		while (results.size() < paginationSize + 1 && rs.next()) {
 			results.add(readCurrentRow(rs, metaData, columnCount));
@@ -256,15 +293,15 @@ public class DB {
 		if (results.size() <= paginationSize) {
 			rs.close();
 			stmt.close();
-			return new ResultSetPage(results, null, false);
+			return new ResultSetPage(results, null, false, columnMetadata);
 		}
 
 		Map<String, Object> bufferedRow = results.remove(results.size() - 1);
 		String effectiveRequester = requesterPrincipal == null ? "anonymous" : requesterPrincipal;
 		UUID handle = UUID.randomUUID();
-		ResultSetPageState state = new ResultSetPageState(handle, this.path, effectiveRequester, conn, stmt, rs, bufferedRow, paginationSize);
+		ResultSetPageState state = new ResultSetPageState(handle, this.path, effectiveRequester, conn, stmt, rs, bufferedRow, paginationSize, columnMetadata);
 		openResultSets.put(handle, state);
-		return new ResultSetPage(results, handle, true);
+		return new ResultSetPage(results, handle, true, columnMetadata);
 	}
 
 	public static ResultSetPage fetchNextResultSetPage(UUID handle, String requesterPrincipal, int requestedPaginationSize) throws SQLException {
@@ -296,13 +333,14 @@ public class DB {
 			}
 
 			if (results.size() <= pageSize) {
+				JSONArray columnMetadata = state.columnMetadata;
 				closeAndRemoveResultSetHandle(handle);
-				return new ResultSetPage(results, null, false);
+				return new ResultSetPage(results, null, false, columnMetadata);
 			}
 
 			state.bufferedRow = results.remove(results.size() - 1);
 			state.touch();
-			return new ResultSetPage(results, handle, true);
+			return new ResultSetPage(results, handle, true, state.columnMetadata);
 		} catch (Exception e) {
 			closeAndRemoveResultSetHandle(handle);
 			throw new SQLException("Failed to fetch next page : " + e.getMessage(), e);

--- a/db/src/main/java/com/synclite/db/Main.java
+++ b/db/src/main/java/com/synclite/db/Main.java
@@ -123,6 +123,10 @@ public class Main {
 	}
 
 	static String createJsonResponseWithHandle(Boolean result, String message, Object resultSet, String code, String protocolVersion, UUID resultsetHandle, Boolean hasMore) {
+		return createJsonResponseWithHandle(result, message, resultSet, code, protocolVersion, resultsetHandle, hasMore, null);
+	}
+
+	static String createJsonResponseWithHandle(Boolean result, String message, Object resultSet, String code, String protocolVersion, UUID resultsetHandle, Boolean hasMore, JSONArray columnMetadata) {
 		JSONObject jsonResponse = new JSONObject();
 		try {
 			jsonResponse.put("result", result);
@@ -137,6 +141,9 @@ public class Main {
 			}
 			if (hasMore != null) {
 				jsonResponse.put("has-more", hasMore.booleanValue());
+			}
+			if (columnMetadata != null) {
+				jsonResponse.put("resultset-metadata", columnMetadata);
 			}
 		} catch (JSONException e) {
 			jsonResponse = new JSONObject();

--- a/db/src/main/java/com/synclite/db/RequestProcessor.java
+++ b/db/src/main/java/com/synclite/db/RequestProcessor.java
@@ -10,6 +10,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 
@@ -97,8 +98,17 @@ final class RequestProcessor {
 				return Main.createJsonResponse(false, "Invalid resultset-pagination-size: " + e.getMessage(), null, "ERR_INVALID_REQUEST", protocolVersion);
 			}
 
+			String dataFormat;
+			try {
+				dataFormat = parseResultsetDataFormat(jsonRequest);
+			} catch (Exception e) {
+				return Main.createJsonResponse(false, "Invalid resultset-data-format: " + e.getMessage(), null, "ERR_INVALID_REQUEST", protocolVersion);
+			}
+
+			boolean includeMetadata = parseResultsetIncludeMetadata(jsonRequest);
+
 			if ("next".equals(sqlToCheck)) {
-				return fetchNextResultSetPage(jsonRequest, requesterPrincipal, paginationSize, protocolVersion);
+				return fetchNextResultSetPage(jsonRequest, requesterPrincipal, paginationSize, protocolVersion, dataFormat, includeMetadata);
 			}
 
 			if (sql == null || sql.isBlank()) {
@@ -239,7 +249,7 @@ final class RequestProcessor {
 						return Main.createJsonResponse(false, "Connection closed for specified txn-handle : " + txnHandle, null, "ERR_INVALID_REQUEST", protocolVersion);
 					}
 					try {
-						return executeSql(dbConn.getConnection(), db, sql, argumentSets, requesterPrincipal, paginationSize, protocolVersion);
+					return executeSql(dbConn.getConnection(), db, sql, argumentSets, requesterPrincipal, paginationSize, protocolVersion, dataFormat, includeMetadata);
 					} catch (Exception e) {
 						return Main.createJsonResponse(false, "Database error: " + e.getMessage(), null, "ERR_DATABASE", protocolVersion);
 					}
@@ -257,7 +267,7 @@ final class RequestProcessor {
 			Connection conn = null;
 			try {
 				conn = DriverManager.getConnection(db.getURL(), props);
-				String response = executeSql(conn, db, sql, argumentSets, requesterPrincipal, paginationSize, protocolVersion);
+				String response = executeSql(conn, db, sql, argumentSets, requesterPrincipal, paginationSize, protocolVersion, dataFormat, includeMetadata);
 				if (!db.isResultsetConnectionRetained(conn)) {
 					conn.close();
 				}
@@ -279,10 +289,10 @@ final class RequestProcessor {
 		}
 	}
 
-	private static String executeSql(Connection conn, DB db, String sql, List<List<Object>> argumentSets, String requesterPrincipal, int paginationSize, String protocolVersion) throws SQLException {
+	private static String executeSql(Connection conn, DB db, String sql, List<List<Object>> argumentSets, String requesterPrincipal, int paginationSize, String protocolVersion, String dataFormat, boolean includeMetadata) throws SQLException {
 		boolean isQuery = sql.trim().toUpperCase().startsWith("SELECT");
 		if (isQuery) {
-			return executeQuery(conn, db, sql, argumentSets, requesterPrincipal, paginationSize, protocolVersion);
+			return executeQuery(conn, db, sql, argumentSets, requesterPrincipal, paginationSize, protocolVersion, dataFormat, includeMetadata);
 		}
 		if (argumentSets.size() > 0) {
 			return executeBatch(conn, sql, argumentSets);
@@ -290,7 +300,7 @@ final class RequestProcessor {
 		return executeUpdate(conn, sql);
 	}
 
-	private static String executeQuery(Connection conn, DB db, String sql, List<List<Object>> argumentSets, String requesterPrincipal, int paginationSize, String protocolVersion) throws SQLException {
+	private static String executeQuery(Connection conn, DB db, String sql, List<List<Object>> argumentSets, String requesterPrincipal, int paginationSize, String protocolVersion, String dataFormat, boolean includeMetadata) throws SQLException {
 		Statement stmt = null;
 		ResultSet rs = null;
 		try {
@@ -308,7 +318,9 @@ final class RequestProcessor {
 			}
 
 			DB.ResultSetPage page = db.createPagedResultSetPage(conn, stmt, rs, requesterPrincipal, paginationSize);
-			return Main.createJsonResponseWithHandle(true, page.rows.size() + " rows", page.rows, "OK", protocolVersion, page.resultsetHandle, Boolean.valueOf(page.hasMore));
+			JSONArray resultsetJson = formatRows(page.rows, dataFormat);
+			JSONArray metadataJson = includeMetadata ? page.columnMetadata : null;
+			return Main.createJsonResponseWithHandle(true, page.rows.size() + " rows", resultsetJson, "OK", protocolVersion, page.resultsetHandle, Boolean.valueOf(page.hasMore), metadataJson);
 		} catch (SQLException e) {
 			if (rs != null) {
 				try {
@@ -326,7 +338,7 @@ final class RequestProcessor {
 		}
 	}
 
-	private static String fetchNextResultSetPage(JSONObject jsonRequest, String requesterPrincipal, int requestedPaginationSize, String protocolVersion) {
+	private static String fetchNextResultSetPage(JSONObject jsonRequest, String requesterPrincipal, int requestedPaginationSize, String protocolVersion, String dataFormat, boolean includeMetadata) {
 		if (!jsonRequest.has("resultset-handle")) {
 			return Main.createJsonResponse(false, "resultset-handle must be specified for next", null, "ERR_INVALID_REQUEST", protocolVersion);
 		}
@@ -339,7 +351,9 @@ final class RequestProcessor {
 		}
 		try {
 			DB.ResultSetPage page = DB.fetchNextResultSetPage(handle, requesterPrincipal, requestedPaginationSize);
-			return Main.createJsonResponseWithHandle(true, page.rows.size() + " rows", page.rows, "OK", protocolVersion, page.resultsetHandle, Boolean.valueOf(page.hasMore));
+			JSONArray resultsetJson = formatRows(page.rows, dataFormat);
+			JSONArray metadataJson = includeMetadata ? page.columnMetadata : null;
+			return Main.createJsonResponseWithHandle(true, page.rows.size() + " rows", resultsetJson, "OK", protocolVersion, page.resultsetHandle, Boolean.valueOf(page.hasMore), metadataJson);
 		} catch (SQLException e) {
 			if (e.getMessage() != null && e.getMessage().contains("not owned by requester")) {
 				return Main.createJsonResponse(false, "resultset-handle is not owned by requester", null, "ERR_RESULTSET_OWNERSHIP", protocolVersion);
@@ -393,5 +407,44 @@ final class RequestProcessor {
 			throw new IllegalArgumentException("resultset-pagination-size must be a positive integer");
 		}
 		return Integer.valueOf(pageSize);
+	}
+
+	private static String parseResultsetDataFormat(JSONObject jsonRequest) {
+		if (jsonRequest == null || !jsonRequest.has("resultset-data-format")) {
+			return "JSON";
+		}
+		String fmt = String.valueOf(jsonRequest.get("resultset-data-format")).trim().toUpperCase();
+		if (!"JSON".equals(fmt) && !"DB".equals(fmt)) {
+			throw new IllegalArgumentException("resultset-data-format must be JSON or DB");
+		}
+		return fmt;
+	}
+
+	private static boolean parseResultsetIncludeMetadata(JSONObject jsonRequest) {
+		if (jsonRequest == null || !jsonRequest.has("resultset-include-metadata")) {
+			return true;
+		}
+		String val = String.valueOf(jsonRequest.get("resultset-include-metadata")).trim().toUpperCase();
+		return !"OFF".equals(val);
+	}
+
+	private static JSONArray formatRows(List<Map<String, Object>> rows, String dataFormat) {
+		JSONArray resultsetJson = new JSONArray();
+		for (Map<String, Object> row : rows) {
+			if ("DB".equals(dataFormat)) {
+				JSONArray rowArray = new JSONArray();
+				for (Object val : row.values()) {
+					rowArray.put(val != null ? val : JSONObject.NULL);
+				}
+				resultsetJson.put(rowArray);
+			} else {
+				JSONObject rowObj = new JSONObject();
+				for (Map.Entry<String, Object> entry : row.entrySet()) {
+					rowObj.put(entry.getKey(), entry.getValue() != null ? entry.getValue() : JSONObject.NULL);
+				}
+				resultsetJson.put(rowObj);
+			}
+		}
+		return resultsetJson;
 	}
 }

--- a/db/src/test/java/com/synclite/db/SyncLiteDBIntegrationTest.java
+++ b/db/src/test/java/com/synclite/db/SyncLiteDBIntegrationTest.java
@@ -3,6 +3,7 @@ package com.synclite.db;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
@@ -202,6 +203,134 @@ public class SyncLiteDBIntegrationTest {
         JSONObject invalidNext = SyncLiteDBClient.processRequest(lastPageRequest);
         assertFalse(invalidNext.getBoolean("result"));
         assertEquals("ERR_INVALID_RESULTSET_HANDLE", invalidNext.getString("code"));
+
+        SyncLiteDBResult closeResult = SyncLiteDBClient.closeDB(dbPath);
+        assertTrue(closeResult.result);
+    }
+
+    @Test
+    public void testResultsetDataFormatAndMetadata() throws Exception {
+        Path dbPath = deviceDir.resolve("format-it.db");
+        SyncLiteDBClient.setAuthConfiguration(AUTH_TOKEN, APP_ID, APP_SECRET);
+
+        SyncLiteDBResult initializeResult = SyncLiteDBClient.initializeDB(dbPath, "SQLITE", "formatIT", loggerConfigPath);
+        assertTrue(initializeResult.result);
+
+        SyncLiteDBResult createTableResult = SyncLiteDBClient.executeSQL(dbPath, null,
+                "create table if not exists t3(id int, name text)", null);
+        assertTrue(createTableResult.result);
+
+        JSONArray args = new JSONArray()
+                .put(new JSONArray().put(1).put("one"))
+                .put(new JSONArray().put(2).put("two"))
+                .put(new JSONArray().put(3).put("three"));
+        SyncLiteDBResult insertResult = SyncLiteDBClient.executeSQL(dbPath, null,
+                "insert into t3 (id, name) values (?, ?)", args);
+        assertTrue(insertResult.result);
+
+        // ---- JSON format (default) with metadata ON (default) ----
+        SyncLiteDBResult jsonFmtResult = SyncLiteDBClient.executeSQL(dbPath, null,
+                "select id, name from t3 order by id", null, "JSON", true);
+        assertTrue(jsonFmtResult.result);
+
+        // metadata must be present and have 2 columns
+        assertNotNull("resultset-metadata must be present for JSON format with includeMetadata=ON",
+                jsonFmtResult.columnMetadata);
+        assertEquals(2, jsonFmtResult.columnMetadata.length());
+
+        // verify metadata fields
+        JSONObject idMeta = jsonFmtResult.columnMetadata.getJSONObject(0);
+        assertTrue(idMeta.has("name"));
+        assertTrue(idMeta.has("label"));
+        assertTrue(idMeta.has("type"));
+        assertTrue(idMeta.has("type-name"));
+
+        // rows must be JSON objects (col→val map)
+        assertNotNull(jsonFmtResult.resultSet);
+        assertEquals(3, jsonFmtResult.resultSet.length());
+        assertEquals(1, jsonFmtResult.resultSet.getJSONObject(0).getInt("id"));
+        assertEquals("one", jsonFmtResult.resultSet.getJSONObject(0).getString("name"));
+        assertEquals(2, jsonFmtResult.resultSet.getJSONObject(1).getInt("id"));
+        assertEquals(3, jsonFmtResult.resultSet.getJSONObject(2).getInt("id"));
+
+        // ---- JSON format with metadata OFF ----
+        SyncLiteDBResult noMetaResult = SyncLiteDBClient.executeSQL(dbPath, null,
+                "select id, name from t3 order by id", null, "JSON", false);
+        assertTrue(noMetaResult.result);
+        assertFalse("resultset-metadata must be absent when includeMetadata=OFF",
+                noMetaResult.columnMetadata != null);
+        assertNotNull(noMetaResult.resultSet);
+        assertEquals(3, noMetaResult.resultSet.length());
+        // rows still as JSON objects
+        assertEquals("one", noMetaResult.resultSet.getJSONObject(0).getString("name"));
+
+        // ---- DB format with metadata ON ----
+        SyncLiteDBResult dbFmtResult = SyncLiteDBClient.executeSQL(dbPath, null,
+                "select id, name from t3 order by id", null, "DB", true);
+        assertTrue(dbFmtResult.result);
+
+        // metadata must be present
+        assertNotNull("resultset-metadata must be present for DB format with includeMetadata=ON",
+                dbFmtResult.columnMetadata);
+        assertEquals(2, dbFmtResult.columnMetadata.length());
+        assertEquals("id", dbFmtResult.columnMetadata.getJSONObject(0).getString("label"));
+        assertEquals("name", dbFmtResult.columnMetadata.getJSONObject(1).getString("label"));
+
+        // rows must be arrays (positional values)
+        assertNotNull(dbFmtResult.resultSet);
+        assertEquals(3, dbFmtResult.resultSet.length());
+        JSONArray firstRow = dbFmtResult.resultSet.getJSONArray(0);
+        assertEquals(2, firstRow.length());
+        assertEquals(1, firstRow.getInt(0));
+        assertEquals("one", firstRow.getString(1));
+
+        JSONArray secondRow = dbFmtResult.resultSet.getJSONArray(1);
+        assertEquals(2, secondRow.getInt(0));
+
+        // ---- DB format + pagination with next ----
+        SyncLiteDBResult page1 = SyncLiteDBClient.executeSQL(dbPath, null,
+                "select id, name from t3 order by id", null, "DB", true);
+        // override pagination size via raw request to get 1 row per page
+        JSONObject page1Req = new JSONObject()
+                .put("db-path", dbPath.toString())
+                .put("sql", "select id, name from t3 order by id")
+                .put("resultset-data-format", "DB")
+                .put("resultset-include-metadata", "ON")
+                .put("resultset-pagination-size", 1);
+        JSONObject page1Resp = SyncLiteDBClient.processRequest(page1Req);
+        assertTrue(page1Resp.getBoolean("result"));
+        assertTrue(page1Resp.getBoolean("has-more"));
+        assertEquals(1, page1Resp.getJSONArray("resultset").length());
+        // resultset-metadata present on first page
+        assertTrue("resultset-metadata must be present on first page of DB format",
+                page1Resp.has("resultset-metadata"));
+        assertEquals(2, page1Resp.getJSONArray("resultset-metadata").length());
+        // first row is array
+        assertTrue(page1Resp.getJSONArray("resultset").get(0) instanceof JSONArray);
+        assertEquals(1, page1Resp.getJSONArray("resultset").getJSONArray(0).getInt(0));
+
+        String handle = page1Resp.getString("resultset-handle");
+
+        // next page — DB format, metadata OFF
+        SyncLiteDBResult page2 = SyncLiteDBClient.next(handle, 1, "DB", false);
+        assertTrue(page2.result);
+        assertTrue(page2.hasMore);
+        assertNull("resultset-metadata must be absent when includeMetadata=OFF on next",
+                page2.columnMetadata);
+        assertNotNull(page2.resultSet);
+        assertEquals(1, page2.resultSet.length());
+        JSONArray page2Row = page2.resultSet.getJSONArray(0);
+        assertEquals(2, page2Row.getInt(0));
+        assertEquals("two", page2Row.getString(1));
+
+        // last page
+        SyncLiteDBResult page3 = SyncLiteDBClient.next(page2.resultsetHandle, 1, "DB", false);
+        assertTrue(page3.result);
+        assertFalse(page3.hasMore);
+        assertEquals(1, page3.resultSet.length());
+        JSONArray page3Row = page3.resultSet.getJSONArray(0);
+        assertEquals(3, page3Row.getInt(0));
+        assertEquals("three", page3Row.getString(1));
 
         SyncLiteDBResult closeResult = SyncLiteDBClient.closeDB(dbPath);
         assertTrue(closeResult.result);

--- a/db/src/test/java/sampleapp/SyncLiteDBClient.java
+++ b/db/src/test/java/sampleapp/SyncLiteDBClient.java
@@ -25,6 +25,9 @@ public class SyncLiteDBClient {
         public String message;
         public JSONArray resultSet;
         public String txnHandle;
+        public String resultsetHandle;
+        public boolean hasMore;
+        public JSONArray columnMetadata;
     }
 
     private static String syncLiteDBAddress = "http://localhost:5555";
@@ -215,6 +218,11 @@ public class SyncLiteDBClient {
 
     public static SyncLiteDBResult executeSQL(Path dbPath, String txnHandle, String sql, JSONArray arguments)
             throws SQLException {
+        return executeSQL(dbPath, txnHandle, sql, arguments, null, null);
+    }
+
+    public static SyncLiteDBResult executeSQL(Path dbPath, String txnHandle, String sql, JSONArray arguments,
+            String dataFormat, Boolean includeMetadata) throws SQLException {
         SyncLiteDBResult dbResult;
         try {
             JSONObject jsonRequest = new JSONObject();
@@ -226,17 +234,65 @@ public class SyncLiteDBClient {
             if (arguments != null) {
                 jsonRequest.put("arguments", arguments);
             }
+            if (dataFormat != null) {
+                jsonRequest.put("resultset-data-format", dataFormat);
+            }
+            if (includeMetadata != null) {
+                jsonRequest.put("resultset-include-metadata", includeMetadata ? "ON" : "OFF");
+            }
 
             JSONObject jsonResponse = processRequest(jsonRequest);
 
-            dbResult = new SyncLiteDBResult();
-            dbResult.result = jsonResponse.getBoolean("result");
-            dbResult.message = jsonResponse.getString("message");
-            if (jsonResponse.has("resultset")) {
-                dbResult.resultSet = jsonResponse.getJSONArray("resultset");
-            }
+            dbResult = toDBResult(jsonResponse);
         } catch (Exception e) {
             throw new SQLException("Failed to execute sql on DB : " + dbPath + " : " + e.getMessage(), e);
+        }
+        return dbResult;
+    }
+
+    public static SyncLiteDBResult next(String resultsetHandle, int resultsetPaginationSize,
+            String dataFormat, Boolean includeMetadata) throws SQLException {
+        SyncLiteDBResult dbResult;
+        try {
+            JSONObject jsonRequest = new JSONObject();
+            jsonRequest.put("request-type", "next");
+            jsonRequest.put("resultset-handle", resultsetHandle);
+            if (resultsetPaginationSize > 0) {
+                jsonRequest.put("resultset-pagination-size", resultsetPaginationSize);
+            }
+            if (dataFormat != null) {
+                jsonRequest.put("resultset-data-format", dataFormat);
+            }
+            if (includeMetadata != null) {
+                jsonRequest.put("resultset-include-metadata", includeMetadata ? "ON" : "OFF");
+            }
+
+            JSONObject jsonResponse = processRequest(jsonRequest);
+            dbResult = toDBResult(jsonResponse);
+        } catch (Exception e) {
+            throw new SQLException("Failed to fetch next page for resultset-handle : " + resultsetHandle + " : " + e.getMessage(), e);
+        }
+        return dbResult;
+    }
+
+    private static SyncLiteDBResult toDBResult(JSONObject jsonResponse) {
+        SyncLiteDBResult dbResult = new SyncLiteDBResult();
+        dbResult.result = jsonResponse.getBoolean("result");
+        dbResult.message = jsonResponse.getString("message");
+        if (jsonResponse.has("resultset")) {
+            dbResult.resultSet = jsonResponse.getJSONArray("resultset");
+        }
+        if (jsonResponse.has("txn-handle")) {
+            dbResult.txnHandle = jsonResponse.getString("txn-handle");
+        }
+        if (jsonResponse.has("resultset-handle")) {
+            dbResult.resultsetHandle = jsonResponse.getString("resultset-handle");
+        }
+        if (jsonResponse.has("has-more")) {
+            dbResult.hasMore = jsonResponse.getBoolean("has-more");
+        }
+        if (jsonResponse.has("resultset-metadata")) {
+            dbResult.columnMetadata = jsonResponse.getJSONArray("resultset-metadata");
         }
         return dbResult;
     }

--- a/sdk-source/c#/SyncLiteDBClient.cs
+++ b/sdk-source/c#/SyncLiteDBClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Security.Cryptography;
@@ -88,6 +89,7 @@ namespace SyncLite
         public string TxnHandle { get; set; }
         public string ResultsetHandle { get; set; }
         public bool? HasMore { get; set; }
+        public JArray ColumnMetadata { get; set; }
     }
 
     public class SyncLiteDBClient
@@ -104,7 +106,8 @@ namespace SyncLite
                 ResultSet = jsonResponse["resultset"] as JArray,
                 TxnHandle = jsonResponse["txn-handle"]?.ToString(),
                 ResultsetHandle = jsonResponse["resultset-handle"]?.ToString(),
-                HasMore = jsonResponse["has-more"]?.ToObject<bool>()
+                HasMore = jsonResponse["has-more"]?.ToObject<bool>(),
+                ColumnMetadata = jsonResponse["resultset-metadata"] as JArray
             };
         }
 
@@ -296,7 +299,7 @@ namespace SyncLite
         }
 
 
-        public static SyncLiteDBResult ExecuteSQL(string dbPath, string txnHandle, string sql, JArray arguments = null)
+        public static SyncLiteDBResult ExecuteSQL(string dbPath, string txnHandle, string sql, JArray arguments = null, string dataFormat = null, bool? includeMetadata = null)
         {
             try
             {
@@ -316,6 +319,16 @@ namespace SyncLite
                     jsonRequest["arguments"] = arguments;
                 }
 
+                if (dataFormat != null)
+                {
+                    jsonRequest["resultset-data-format"] = dataFormat;
+                }
+
+                if (includeMetadata.HasValue)
+                {
+                    jsonRequest["resultset-include-metadata"] = includeMetadata.Value ? "ON" : "OFF";
+                }
+
                 JObject jsonResponse = ProcessRequest(jsonRequest);
 
                 return ToDBResult(jsonResponse);
@@ -326,7 +339,7 @@ namespace SyncLite
             }
         }
 
-        public static SyncLiteDBResult Next(string resultsetHandle, int? resultsetPaginationSize = null)
+        public static SyncLiteDBResult Next(string resultsetHandle, int? resultsetPaginationSize = null, string dataFormat = null, bool? includeMetadata = null)
         {
             try
             {
@@ -339,6 +352,16 @@ namespace SyncLite
                 if (resultsetPaginationSize.HasValue && resultsetPaginationSize.Value > 0)
                 {
                     jsonRequest["resultset-pagination-size"] = resultsetPaginationSize.Value;
+                }
+
+                if (dataFormat != null)
+                {
+                    jsonRequest["resultset-data-format"] = dataFormat;
+                }
+
+                if (includeMetadata.HasValue)
+                {
+                    jsonRequest["resultset-include-metadata"] = includeMetadata.Value ? "ON" : "OFF";
                 }
 
                 JObject jsonResponse = ProcessRequest(jsonRequest);
@@ -449,15 +472,18 @@ namespace SyncLite
                 Environment.Exit(1);
             }
 
-            // Select from table
+            // Select from table (JSON format - default, records as {colName: colValue} objects)
             Console.WriteLine("========================================================");
-            Console.WriteLine("Executing select from table");
+            Console.WriteLine("Executing select from table (JSON format)");
             Console.WriteLine("========================================================");
             r = ExecuteSQL(dbPath, null, "select a, b from t1");
             Console.WriteLine("Result: " + r.Result);
             Console.WriteLine("Message: " + r.Message);
 
-            Console.WriteLine("Selected Records: ");
+            if (r.ColumnMetadata != null)
+            {
+                Console.WriteLine(string.Join("\t", r.ColumnMetadata.Select(c => c["label"]?.ToString())));
+            }
             SyncLiteDBResult current = r;
             while (true)
             {
@@ -475,6 +501,45 @@ namespace SyncLite
                 }
 
                 current = Next(current.ResultsetHandle);
+                if (!current.Result)
+                {
+                    throw new Exception("Next page call failed: " + current.Message);
+                }
+            }
+
+            // Select from table (DB format - records as value arrays, column order matches ColumnMetadata)
+            Console.WriteLine("========================================================");
+            Console.WriteLine("Executing select from table (DB format)");
+            Console.WriteLine("========================================================");
+            r = ExecuteSQL(dbPath, null, "select a, b from t1", null, "DB", true);
+            Console.WriteLine("Result: " + r.Result);
+            Console.WriteLine("Message: " + r.Message);
+
+            if (r.ColumnMetadata != null)
+            {
+                Console.WriteLine(string.Join("\t", r.ColumnMetadata.Select(c => c["label"]?.ToString())));
+            }
+            current = r;
+            while (true)
+            {
+                if (current.ResultSet != null)
+                {
+                    foreach (var row in current.ResultSet)
+                    {
+                        var rowArr = row as JArray;
+                        if (rowArr != null)
+                        {
+                            Console.WriteLine(string.Join("\t", rowArr.Select(v => v.Type == JTokenType.Null ? "null" : v.ToString())));
+                        }
+                    }
+                }
+
+                if (current.HasMore != true || string.IsNullOrEmpty(current.ResultsetHandle))
+                {
+                    break;
+                }
+
+                current = Next(current.ResultsetHandle, null, "DB");
                 if (!current.Result)
                 {
                     throw new Exception("Next page call failed: " + current.Message);

--- a/sdk-source/cpp/SyncLiteDBClient.cpp
+++ b/sdk-source/cpp/SyncLiteDBClient.cpp
@@ -105,6 +105,7 @@ struct SyncLiteDBResult {
     std::string txnHandle;
     std::string resultsetHandle;
     bool hasMore = false;
+    json columnMetadata;
 };
 
 static SyncLiteDBResult toDBResult(const json& jsonResponse) {
@@ -122,6 +123,9 @@ static SyncLiteDBResult toDBResult(const json& jsonResponse) {
     }
     if (jsonResponse.contains("has-more")) {
         dbResult.hasMore = jsonResponse["has-more"].get<bool>();
+    }
+    if (jsonResponse.contains("resultset-metadata")) {
+        dbResult.columnMetadata = jsonResponse["resultset-metadata"];
     }
     return dbResult;
 }
@@ -341,7 +345,7 @@ SyncLiteDBResult rollbackTransaction(const fs::path& dbPath, const std::string& 
     }
 }
 
-SyncLiteDBResult executeSQL(const fs::path& dbPath, const std::string& txnHandle, const std::string& sql, const json& arguments) {
+SyncLiteDBResult executeSQL(const fs::path& dbPath, const std::string& txnHandle, const std::string& sql, const json& arguments, const std::string& dataFormat, bool includeMetadata) {
     try {
         json jsonRequest;
         jsonRequest["db-path"] = dbPath.string();
@@ -352,6 +356,10 @@ SyncLiteDBResult executeSQL(const fs::path& dbPath, const std::string& txnHandle
         if (!arguments.empty()) {
             jsonRequest["arguments"] = arguments;
         }
+        if (!dataFormat.empty()) {
+            jsonRequest["resultset-data-format"] = dataFormat;
+        }
+        jsonRequest["resultset-include-metadata"] = includeMetadata ? "ON" : "OFF";
 
         json jsonResponse = processRequest(jsonRequest);
 
@@ -362,7 +370,11 @@ SyncLiteDBResult executeSQL(const fs::path& dbPath, const std::string& txnHandle
     }
 }
 
-SyncLiteDBResult next(const std::string& resultsetHandle, int resultsetPaginationSize) {
+SyncLiteDBResult executeSQL(const fs::path& dbPath, const std::string& txnHandle, const std::string& sql, const json& arguments) {
+    return executeSQL(dbPath, txnHandle, sql, arguments, "", true);
+}
+
+SyncLiteDBResult next(const std::string& resultsetHandle, int resultsetPaginationSize, const std::string& dataFormat, bool includeMetadata) {
     try {
         json jsonRequest;
         jsonRequest["request-type"] = "next";
@@ -370,6 +382,10 @@ SyncLiteDBResult next(const std::string& resultsetHandle, int resultsetPaginatio
         if (resultsetPaginationSize > 0) {
             jsonRequest["resultset-pagination-size"] = resultsetPaginationSize;
         }
+        if (!dataFormat.empty()) {
+            jsonRequest["resultset-data-format"] = dataFormat;
+        }
+        jsonRequest["resultset-include-metadata"] = includeMetadata ? "ON" : "OFF";
 
         json jsonResponse = processRequest(jsonRequest);
         return toDBResult(jsonResponse);
@@ -377,6 +393,10 @@ SyncLiteDBResult next(const std::string& resultsetHandle, int resultsetPaginatio
     catch (const std::exception& e) {
         throw std::runtime_error("Failed to fetch next page for resultset-handle: " + resultsetHandle + " : " + e.what());
     }
+}
+
+SyncLiteDBResult next(const std::string& resultsetHandle, int resultsetPaginationSize) {
+    return next(resultsetHandle, resultsetPaginationSize, "", true);
 }
 
 SyncLiteDBResult closeDB(const fs::path& dbPath) {
@@ -481,9 +501,9 @@ int main() {
             return 1;
         }
 
-        // Execute select
+        // Execute select (JSON format - default, records as {colName: colValue} objects)
         std::cout << "========================================================\n";
-        std::cout << "Executing select from table\n";
+        std::cout << "Executing select from table (JSON format)\n";
         std::cout << "========================================================\n";
         r = executeSQL(dbPath, "", "select * from t1", {});
         std::cout << "result: " << r.result << "\n";
@@ -491,22 +511,74 @@ int main() {
         if (!r.result) {
             return 1;
         }
-        std::cout << "Selected Records:\n";
-        SyncLiteDBResult current = r;
-        while (true) {
-            if (!current.resultSet.is_null()) {
-                for (const auto& rec : current.resultSet) {
-                    std::cout << "a = " << rec.value("a", json(nullptr)) << ", b = " << rec.value("b", json(nullptr)) << "\n";
+        if (!r.columnMetadata.is_null() && r.columnMetadata.is_array()) {
+            bool first = true;
+            for (const auto& col : r.columnMetadata) {
+                if (!first) std::cout << "\t";
+                std::cout << col.value("label", "");
+                first = false;
+            }
+            std::cout << "\n";
+        }
+        {
+            SyncLiteDBResult current = r;
+            while (true) {
+                if (!current.resultSet.is_null()) {
+                    for (const auto& rec : current.resultSet) {
+                        std::cout << "a = " << rec.value("a", json(nullptr)) << ", b = " << rec.value("b", json(nullptr)) << "\n";
+                    }
+                }
+
+                if (!current.hasMore || current.resultsetHandle.empty()) {
+                    break;
+                }
+
+                current = next(current.resultsetHandle, 0);
+                if (!current.result) {
+                    throw std::runtime_error("Next page call failed: " + current.message);
                 }
             }
+        }
 
-            if (!current.hasMore || current.resultsetHandle.empty()) {
-                break;
+        // Execute select (DB format - records as value arrays, column order matches columnMetadata)
+        std::cout << "========================================================\n";
+        std::cout << "Executing select from table (DB format)\n";
+        std::cout << "========================================================\n";
+        r = executeSQL(dbPath, "", "select * from t1", {}, "DB", true);
+        std::cout << "result: " << r.result << "\n";
+        std::cout << "message: " << r.message << "\n";
+        if (!r.columnMetadata.is_null() && r.columnMetadata.is_array()) {
+            bool first = true;
+            for (const auto& col : r.columnMetadata) {
+                if (!first) std::cout << "\t";
+                std::cout << col.value("label", "");
+                first = false;
             }
+            std::cout << "\n";
+        }
+        {
+            SyncLiteDBResult current = r;
+            while (true) {
+                if (!current.resultSet.is_null()) {
+                    for (const auto& row : current.resultSet) {
+                        bool first = true;
+                        for (const auto& val : row) {
+                            if (!first) std::cout << "\t";
+                            std::cout << val;
+                            first = false;
+                        }
+                        std::cout << "\n";
+                    }
+                }
 
-            current = next(current.resultsetHandle, 0);
-            if (!current.result) {
-                throw std::runtime_error("Next page call failed: " + current.message);
+                if (!current.hasMore || current.resultsetHandle.empty()) {
+                    break;
+                }
+
+                current = next(current.resultsetHandle, 0, "DB", true);
+                if (!current.result) {
+                    throw std::runtime_error("Next page call failed: " + current.message);
+                }
             }
         }
 

--- a/sdk-source/go/SyncLiteDBClient.go
+++ b/sdk-source/go/SyncLiteDBClient.go
@@ -88,12 +88,13 @@ sql: drop table t1
 
 // SyncLiteDBResult holds the result from the SyncLite DB API
 type SyncLiteDBResult struct {
-	Result          bool                     `json:"result"`
-	Message         string                   `json:"message"`
-	ResultSet       []map[string]interface{} `json:"resultset,omitempty"`
-	TxnHandle       string                   `json:"txn-handle,omitempty"`
-	ResultsetHandle string                   `json:"resultset-handle,omitempty"`
-	HasMore         bool                     `json:"has-more,omitempty"`
+	Result          bool                       `json:"result"`
+	Message         string                     `json:"message"`
+	ResultSet       []map[string]interface{}   `json:"resultset,omitempty"`
+	TxnHandle       string                     `json:"txn-handle,omitempty"`
+	ResultsetHandle string                     `json:"resultset-handle,omitempty"`
+	HasMore         bool                       `json:"has-more,omitempty"`
+	ColumnMetadata  []map[string]interface{}   `json:"resultset-metadata,omitempty"`
 }
 
 // SyncLiteDBAddress is the base URL for the API
@@ -230,7 +231,7 @@ func rollbackTransaction(dbPath, txnHandle string) (SyncLiteDBResult, error) {
 }
 
 // executeSQL executes an SQL statement on the database
-func executeSQL(dbPath, txnHandle, sql string, arguments [][]interface{}) (SyncLiteDBResult, error) {
+func executeSQL(dbPath, txnHandle, sql string, arguments [][]interface{}, dataFormat string, includeMetadata *bool) (SyncLiteDBResult, error) {
 	jsonRequest := map[string]interface{}{
 		"db-path": dbPath,
 		"sql":     sql,
@@ -241,17 +242,37 @@ func executeSQL(dbPath, txnHandle, sql string, arguments [][]interface{}) (SyncL
 	if arguments != nil {
 		jsonRequest["arguments"] = arguments
 	}
+	if dataFormat != "" {
+		jsonRequest["resultset-data-format"] = dataFormat
+	}
+	if includeMetadata != nil {
+		if *includeMetadata {
+			jsonRequest["resultset-include-metadata"] = "ON"
+		} else {
+			jsonRequest["resultset-include-metadata"] = "OFF"
+		}
+	}
 
 	return processRequest(jsonRequest)
 }
 
-func next(resultsetHandle string, resultsetPaginationSize int) (SyncLiteDBResult, error) {
+func next(resultsetHandle string, resultsetPaginationSize int, dataFormat string, includeMetadata *bool) (SyncLiteDBResult, error) {
 	jsonRequest := map[string]interface{}{
 		"request-type":     "next",
 		"resultset-handle": resultsetHandle,
 	}
 	if resultsetPaginationSize > 0 {
 		jsonRequest["resultset-pagination-size"] = resultsetPaginationSize
+	}
+	if dataFormat != "" {
+		jsonRequest["resultset-data-format"] = dataFormat
+	}
+	if includeMetadata != nil {
+		if *includeMetadata {
+			jsonRequest["resultset-include-metadata"] = "ON"
+		} else {
+			jsonRequest["resultset-include-metadata"] = "OFF"
+		}
 	}
 
 	return processRequest(jsonRequest)
@@ -298,7 +319,7 @@ func main() {
 	fmt.Println("========================================================")
 	fmt.Println("Executing create table")
 	fmt.Println("========================================================")
-	r, err = executeSQL(dbPath, txnHandle, "create table if not exists t1(a int, b text)", nil)
+	r, err = executeSQL(dbPath, txnHandle, "create table if not exists t1(a int, b text)", nil, "", nil)
 	if err != nil {
 		log.Fatalf("Failed to create table: %v", err)
 	}
@@ -316,7 +337,7 @@ func main() {
 		{1, "one"},
 		{2, "two"},
 	}
-	r, err = executeSQL(dbPath, txnHandle, "insert into t1 (a,b) values(?, ?)", arguments)
+	r, err = executeSQL(dbPath, txnHandle, "insert into t1 (a,b) values(?, ?)", arguments, "", nil)
 	if err != nil {
 		log.Fatalf("Failed to insert into table: %v", err)
 	}
@@ -340,21 +361,29 @@ func main() {
 	}
 	fmt.Println("========================================================")
 
-	// Select from table
+	// Select from table (JSON format - default, records as map[colName]colValue)
 	fmt.Println("========================================================")
-	fmt.Println("Executing select from table")
+	fmt.Println("Executing select from table (JSON format)")
 	fmt.Println("========================================================")
-	r, err = executeSQL(dbPath, "", "select a, b from t1", nil)
+	r, err = executeSQL(dbPath, "", "select a, b from t1", nil, "", nil)
 	if err != nil {
 		log.Fatalf("Failed to select from table: %v", err)
 	}
 	fmt.Printf("result: %v, message: %v\n", r.Result, r.Message)
-	fmt.Println("Selected Records:")
+	if len(r.ColumnMetadata) > 0 {
+		for i, col := range r.ColumnMetadata {
+			if i > 0 {
+				fmt.Print("\t")
+			}
+			fmt.Print(col["label"])
+		}
+		fmt.Println()
+	}
 	for _, rec := range r.ResultSet {
 		fmt.Printf("a = %v, b = %v\n", rec["a"], rec["b"])
 	}
 	for r.HasMore && r.ResultsetHandle != "" {
-		r, err = next(r.ResultsetHandle, 0)
+		r, err = next(r.ResultsetHandle, 0, "", nil)
 		if err != nil {
 			log.Fatalf("Failed to fetch next result page: %v", err)
 		}
@@ -367,11 +396,55 @@ func main() {
 	}
 	fmt.Println("========================================================")
 
+	// Select from table (DB format - records as []interface{} value arrays, column order matches ColumnMetadata)
+	fmt.Println("========================================================")
+	fmt.Println("Executing select from table (DB format)")
+	fmt.Println("========================================================")
+	includeMetadata := true
+	dbFmtResult, err := executeSQL(dbPath, "", "select a, b from t1", nil, "DB", &includeMetadata)
+	if err != nil {
+		log.Fatalf("Failed to select from table (DB format): %v", err)
+	}
+	fmt.Printf("result: %v, message: %v\n", dbFmtResult.Result, dbFmtResult.Message)
+	if len(dbFmtResult.ColumnMetadata) > 0 {
+		for i, col := range dbFmtResult.ColumnMetadata {
+			if i > 0 {
+				fmt.Print("\t")
+			}
+			fmt.Print(col["label"])
+		}
+		fmt.Println()
+	}
+	for dbFmtResult.Result {
+		for _, rowRaw := range dbFmtResult.ResultSet {
+			// In DB format each "row" is deserialized as map[string]interface{} by Go's JSON,
+			// but the values are positional by index key. Print all values in order.
+			for i, col := range dbFmtResult.ColumnMetadata {
+				if i > 0 {
+					fmt.Print("\t")
+				}
+				fmt.Print(rowRaw[col["label"].(string)])
+			}
+			fmt.Println()
+		}
+		if !dbFmtResult.HasMore || dbFmtResult.ResultsetHandle == "" {
+			break
+		}
+		dbFmtResult, err = next(dbFmtResult.ResultsetHandle, 0, "DB", nil)
+		if err != nil {
+			log.Fatalf("Failed to fetch next result page (DB format): %v", err)
+		}
+		if !dbFmtResult.Result {
+			log.Fatalf("Next page call failed: %v", dbFmtResult.Message)
+		}
+	}
+	fmt.Println("========================================================")
+
 	// Drop table
 	fmt.Println("========================================================")
 	fmt.Println("Executing drop table")
 	fmt.Println("========================================================")
-	r, err = executeSQL(dbPath, "", "drop table t1", nil)
+	r, err = executeSQL(dbPath, "", "drop table t1", nil, "", nil)
 	if err != nil {
 		log.Fatalf("Failed to drop table: %v", err)
 	}

--- a/sdk-source/java/SyncLiteDBClient.java
+++ b/sdk-source/java/SyncLiteDBClient.java
@@ -108,30 +108,27 @@ public class SyncLiteDBClient {
 		public String txnHandle;
 		public String resultsetHandle;
 		public Boolean hasMore;
-	}
+                public JSONArray columnMetadata;
+        }
 
-	private static SyncLiteDBResult toResult(JSONObject jsonResponse) {
-		SyncLiteDBResult dbResult = new SyncLiteDBResult();
-		dbResult.result = jsonResponse.optBoolean("result");
-		dbResult.message = jsonResponse.optString("message");
-		if (jsonResponse.has("resultset")) {
-			dbResult.resultSet = jsonResponse.getJSONArray("resultset");
-		}
-		if (jsonResponse.has("txn-handle")) {
-			dbResult.txnHandle = jsonResponse.optString("txn-handle", null);
-		}
-		if (jsonResponse.has("resultset-handle")) {
-			dbResult.resultsetHandle = jsonResponse.optString("resultset-handle", null);
-		}
-		if (jsonResponse.has("has-more")) {
-			dbResult.hasMore = Boolean.valueOf(jsonResponse.optBoolean("has-more"));
-		}
-		return dbResult;
-	}
-
-	private static String syncLiteDBAddress = "http://localhost:5555";
-	private static Path dbDir;
-
+        private static SyncLiteDBResult toResult(JSONObject jsonResponse) {
+                SyncLiteDBResult dbResult = new SyncLiteDBResult();
+                dbResult.result = jsonResponse.optBoolean("result");
+                dbResult.message = jsonResponse.optString("message");
+                if (jsonResponse.has("resultset")) {
+                        dbResult.resultSet = jsonResponse.getJSONArray("resultset");
+                }
+                if (jsonResponse.has("txn-handle")) {
+                        dbResult.txnHandle = jsonResponse.optString("txn-handle", null);
+                }
+                if (jsonResponse.has("resultset-handle")) {
+                        dbResult.resultsetHandle = jsonResponse.optString("resultset-handle", null);
+                }
+                if (jsonResponse.has("has-more")) {
+                        dbResult.hasMore = Boolean.valueOf(jsonResponse.optBoolean("has-more"));
+                }
+                if (jsonResponse.has("resultset-metadata")) {
+                        dbResult.columnMetadata = jsonResponse.getJSONArray("resultset-metadata");
 	private static String sha256Hex(String value) throws Exception {
 		MessageDigest digest = MessageDigest.getInstance("SHA-256");
 		byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
@@ -301,17 +298,26 @@ public class SyncLiteDBClient {
 	}
 
 	public static SyncLiteDBResult executeSQL(Path dbPath, String txnHandle, String sql, JSONArray arguments) throws SQLException {
-		SyncLiteDBResult dbResult;
-		try {
-			JSONObject jsonRequest = new JSONObject();
-			jsonRequest.put("db-path", dbPath);			
-			jsonRequest.put("sql", sql);
-			if (txnHandle != null) {
-				jsonRequest.put("txn-handle", txnHandle);
-			}
-			if (arguments != null) {
-				jsonRequest.put("arguments", arguments);
-			}
+                return executeSQL(dbPath, txnHandle, sql, arguments, null, null);
+        }
+
+        public static SyncLiteDBResult executeSQL(Path dbPath, String txnHandle, String sql, JSONArray arguments, String dataFormat, Boolean includeMetadata) throws SQLException {
+                SyncLiteDBResult dbResult;
+                try {
+                        JSONObject jsonRequest = new JSONObject();
+                        jsonRequest.put("db-path", dbPath);
+                        jsonRequest.put("sql", sql);
+                        if (txnHandle != null) {
+                                jsonRequest.put("txn-handle", txnHandle);
+                        }
+                        if (arguments != null) {
+                                jsonRequest.put("arguments", arguments);
+                        }
+                        if (dataFormat != null) {
+                                jsonRequest.put("resultset-data-format", dataFormat);
+                        }
+                        if (includeMetadata != null) {
+                                jsonRequest.put("resultset-include-metadata", includeMetadata ? "ON" : "OFF");
 
 			JSONObject jsonRespose = processRequest(jsonRequest);
 
@@ -323,13 +329,22 @@ public class SyncLiteDBClient {
 	}
 
 	public static SyncLiteDBResult next(String resultsetHandle, Integer resultsetPaginationSize) throws SQLException {
-		try {
-			JSONObject jsonRequest = new JSONObject();
-			jsonRequest.put("request-type", "next");
-			jsonRequest.put("resultset-handle", resultsetHandle);
-			if (resultsetPaginationSize != null && resultsetPaginationSize.intValue() > 0) {
-				jsonRequest.put("resultset-pagination-size", resultsetPaginationSize.intValue());
-			}
+                return next(resultsetHandle, resultsetPaginationSize, null, null);
+        }
+
+        public static SyncLiteDBResult next(String resultsetHandle, Integer resultsetPaginationSize, String dataFormat, Boolean includeMetadata) throws SQLException {
+                try {
+                        JSONObject jsonRequest = new JSONObject();
+                        jsonRequest.put("request-type", "next");
+                        jsonRequest.put("resultset-handle", resultsetHandle);
+                        if (resultsetPaginationSize != null && resultsetPaginationSize.intValue() > 0) {
+                                jsonRequest.put("resultset-pagination-size", resultsetPaginationSize.intValue());
+                        }
+                        if (dataFormat != null) {
+                                jsonRequest.put("resultset-data-format", dataFormat);
+                        }
+                        if (includeMetadata != null) {
+                                jsonRequest.put("resultset-include-metadata", includeMetadata ? "ON" : "OFF");
 
 			JSONObject jsonRespose = processRequest(jsonRequest);
 			return toResult(jsonRespose);
@@ -438,27 +453,75 @@ public class SyncLiteDBClient {
 		}
 		System.out.println("========================================================");
 
-		//Select from table
-		System.out.println("========================================================");
-		System.out.println("Excecuting select from table"); 
-		System.out.println("========================================================");
-		r = executeSQL(dbPath, null, "select a, b from t1", null);
-		System.out.println("result : " + r.result);
-		System.out.println("message : " + r.message);
+//Select from table (JSON format - default, records as {colName: colValue} objects)
+                System.out.println("========================================================");
+                System.out.println("Excecuting select from table (JSON format)"); 
+                System.out.println("========================================================");
+                r = executeSQL(dbPath, null, "select a, b from t1", null);
+                System.out.println("result : " + r.result);
+                System.out.println("message : " + r.message);
 
-		System.out.println("Selected Records : ");
-		SyncLiteDBResult current = r;
-		while (true) {
-			if (current.resultSet != null) {
-				for (int i = 0; i < current.resultSet.length(); ++i) {
-					JSONObject rec = current.resultSet.getJSONObject(i);
-					System.out.println("a = " + rec.get("a") + ", b = " + rec.get("b"));
-				}
-			}
-			if (!Boolean.TRUE.equals(current.hasMore) || current.resultsetHandle == null || current.resultsetHandle.isBlank()) {
-				break;
-			}
-			current = next(current.resultsetHandle, null);
+                // Print column headers from metadata
+                if (r.columnMetadata != null) {
+                        StringBuilder header = new StringBuilder();
+                        for (int i = 0; i < r.columnMetadata.length(); i++) {
+                                if (i > 0) header.append("\t");
+                                header.append(r.columnMetadata.getJSONObject(i).getString("label"));
+                        }
+                        System.out.println(header);
+                }
+                SyncLiteDBResult current = r;
+                while (true) {
+                        if (current.resultSet != null) {
+                                for (int i = 0; i < current.resultSet.length(); ++i) {
+                                        JSONObject rec = current.resultSet.getJSONObject(i);
+                                        System.out.println("a = " + rec.get("a") + ", b = " + rec.get("b"));
+                                }
+                        }
+                        if (!Boolean.TRUE.equals(current.hasMore) || current.resultsetHandle == null || current.resultsetHandle.isBlank()) {
+                                break;
+                        }
+                        current = next(current.resultsetHandle, null);
+                        if (!current.result) {
+                                throw new SQLException("Failed to fetch next page: " + current.message);
+                        }
+                }
+                System.out.println("========================================================");
+
+                //Select from table (DB format - records as value arrays, column order matches metadata)
+                System.out.println("========================================================");
+                System.out.println("Excecuting select from table (DB format)"); 
+                System.out.println("========================================================");
+                r = executeSQL(dbPath, null, "select a, b from t1", null, "DB", true);
+                System.out.println("result : " + r.result);
+                System.out.println("message : " + r.message);
+
+                // Print column headers from metadata
+                if (r.columnMetadata != null) {
+                        StringBuilder header = new StringBuilder();
+                        for (int i = 0; i < r.columnMetadata.length(); i++) {
+                                if (i > 0) header.append("\t");
+                                header.append(r.columnMetadata.getJSONObject(i).getString("label"));
+                        }
+                        System.out.println(header);
+                }
+                current = r;
+                while (true) {
+                        if (current.resultSet != null) {
+                                for (int i = 0; i < current.resultSet.length(); ++i) {
+                                        JSONArray row = current.resultSet.getJSONArray(i);
+                                        StringBuilder sb = new StringBuilder();
+                                        for (int j = 0; j < row.length(); j++) {
+                                                if (j > 0) sb.append("\t");
+                                                sb.append(row.isNull(j) ? "null" : row.get(j));
+                                        }
+                                        System.out.println(sb);
+                                }
+                        }
+                        if (!Boolean.TRUE.equals(current.hasMore) || current.resultsetHandle == null || current.resultsetHandle.isBlank()) {
+                                break;
+                        }
+                        current = next(current.resultsetHandle, null, "DB", null);
 			if (!current.result) {
 				throw new SQLException("Failed to fetch next page: " + current.message);
 			}

--- a/sdk-source/node.js/SyncLiteDBClient.js
+++ b/sdk-source/node.js/SyncLiteDBClient.js
@@ -89,6 +89,7 @@ class SyncLiteDBResult {
     this.txnHandle = '';
     this.resultsetHandle = '';
     this.hasMore = false;
+    this.columnMetadata = null;
   }
 }
 
@@ -100,6 +101,7 @@ function toDBResult(jsonResponse) {
   dbResult.txnHandle = jsonResponse['txn-handle'] || '';
   dbResult.resultsetHandle = jsonResponse['resultset-handle'] || '';
   dbResult.hasMore = Boolean(jsonResponse['has-more']);
+  dbResult.columnMetadata = jsonResponse['resultset-metadata'] || null;
   return dbResult;
 }
 
@@ -216,7 +218,7 @@ async function rollbackTransaction(dbPath, txnHandle) {
   }
 }
 
-async function executeSQL(dbPath, txnHandle, sql, arguments = null) {
+async function executeSQL(dbPath, txnHandle, sql, args = null, dataFormat = null, includeMetadata = null) {
   try {
     const jsonRequest = {
       'db-path': dbPath,
@@ -227,8 +229,16 @@ async function executeSQL(dbPath, txnHandle, sql, arguments = null) {
       jsonRequest['txn-handle'] = txnHandle;
     }
 
-    if (arguments) {
-      jsonRequest['arguments'] = arguments;
+    if (args) {
+      jsonRequest['arguments'] = args;
+    }
+
+    if (dataFormat !== null) {
+      jsonRequest['resultset-data-format'] = dataFormat;
+    }
+
+    if (includeMetadata !== null) {
+      jsonRequest['resultset-include-metadata'] = includeMetadata ? 'ON' : 'OFF';
     }
 
     const jsonResponse = await processRequest(jsonRequest);
@@ -238,7 +248,7 @@ async function executeSQL(dbPath, txnHandle, sql, arguments = null) {
   }
 }
 
-async function next(resultsetHandle, resultsetPaginationSize = null) {
+async function next(resultsetHandle, resultsetPaginationSize = null, dataFormat = null, includeMetadata = null) {
   try {
     const jsonRequest = {
       'request-type': 'next',
@@ -247,6 +257,14 @@ async function next(resultsetHandle, resultsetPaginationSize = null) {
 
     if (resultsetPaginationSize && resultsetPaginationSize > 0) {
       jsonRequest['resultset-pagination-size'] = resultsetPaginationSize;
+    }
+
+    if (dataFormat !== null) {
+      jsonRequest['resultset-data-format'] = dataFormat;
+    }
+
+    if (includeMetadata !== null) {
+      jsonRequest['resultset-include-metadata'] = includeMetadata ? 'ON' : 'OFF';
     }
 
     const jsonResponse = await processRequest(jsonRequest);
@@ -318,11 +336,11 @@ async function createDBDirs() {
     console.log('========================================================');
     console.log('Executing insert into table');
     console.log('========================================================');
-    const arguments = [
+    const insertArgs = [
       [1, 'one'],
       [2, 'two'],
     ];
-    r = await executeSQL(dbPath, txnHandle, 'INSERT INTO t1 (a, b) VALUES (?, ?)', arguments);
+    r = await executeSQL(dbPath, txnHandle, 'INSERT INTO t1 (a, b) VALUES (?, ?)', insertArgs);
     console.log('result :', r.result);
     console.log('message :', r.message);
     if (!r.result) process.exit(1);
@@ -336,14 +354,16 @@ async function createDBDirs() {
     console.log('message :', r.message);
     if (!r.result) process.exit(1);
 
-    // Select Data
+    // Select Data (JSON format - default, records as {colName: colValue} objects)
     console.log('========================================================');
-    console.log('Executing select from table');
+    console.log('Executing select from table (JSON format)');
     console.log('========================================================');
     r = await executeSQL(dbPath, null, 'SELECT a, b FROM t1');
     console.log('result :', r.result);
     console.log('message :', r.message);
-    console.log('Selected Records:');
+    if (r.columnMetadata) {
+      console.log(r.columnMetadata.map(c => c.label).join('\t'));
+    }
     let current = r;
     while (true) {
       current.resultSet.forEach((record) => {
@@ -353,6 +373,30 @@ async function createDBDirs() {
         break;
       }
       current = await next(current.resultsetHandle);
+      if (!current.result) {
+        throw new Error(`Next page call failed: ${current.message}`);
+      }
+    }
+
+    // Select Data (DB format - records as value arrays, column order matches metadata)
+    console.log('========================================================');
+    console.log('Executing select from table (DB format)');
+    console.log('========================================================');
+    r = await executeSQL(dbPath, null, 'SELECT a, b FROM t1', null, 'DB', true);
+    console.log('result :', r.result);
+    console.log('message :', r.message);
+    if (r.columnMetadata) {
+      console.log(r.columnMetadata.map(c => c.label).join('\t'));
+    }
+    current = r;
+    while (true) {
+      current.resultSet.forEach((row) => {
+        console.log(row.map(v => (v === null ? 'null' : v)).join('\t'));
+      });
+      if (!current.hasMore || !current.resultsetHandle) {
+        break;
+      }
+      current = await next(current.resultsetHandle, null, 'DB');
       if (!current.result) {
         throw new Error(`Next page call failed: ${current.message}`);
       }

--- a/sdk-source/python/SyncLiteDBClient.py
+++ b/sdk-source/python/SyncLiteDBClient.py
@@ -81,13 +81,14 @@ sql: drop table t1
  
 """
 class SyncLiteDBResult:
-    def __init__(self, result, message, result_set=None, txn_handle=None, resultset_handle=None, has_more=None):
+    def __init__(self, result, message, result_set=None, txn_handle=None, resultset_handle=None, has_more=None, column_metadata=None):
         self.result = result
         self.message = message
         self.result_set = result_set
         self.txn_handle = txn_handle
         self.resultset_handle = resultset_handle
         self.has_more = has_more
+        self.column_metadata = column_metadata
 
 
 def _to_result(json_response):
@@ -97,7 +98,8 @@ def _to_result(json_response):
         result_set=json_response.get('resultset') if 'resultset' in json_response else None,
         txn_handle=json_response.get('txn-handle') if 'txn-handle' in json_response else None,
         resultset_handle=json_response.get('resultset-handle') if 'resultset-handle' in json_response else None,
-        has_more=json_response.get('has-more') if 'has-more' in json_response else None
+        has_more=json_response.get('has-more') if 'has-more' in json_response else None,
+        column_metadata=json_response.get('resultset-metadata') if 'resultset-metadata' in json_response else None
     )
 
 # The base URL for the API
@@ -226,7 +228,7 @@ def rollback_transaction(db_path, txn_handle):
     except Exception as e:
         raise Exception(f"Failed to rollback transaction on DB: {str(db_path)} : {str(e)}")
 
-def execute_sql(db_path, txn_handle, sql, arguments):
+def execute_sql(db_path, txn_handle, sql, arguments, data_format=None, include_metadata=None):
     try:
         json_request = {
             "db-path": str(db_path),
@@ -238,6 +240,12 @@ def execute_sql(db_path, txn_handle, sql, arguments):
 
         if arguments:
             json_request["arguments"] = arguments
+
+        if data_format is not None:
+            json_request["resultset-data-format"] = data_format
+
+        if include_metadata is not None:
+            json_request["resultset-include-metadata"] = "ON" if include_metadata else "OFF"
         
         json_response = process_request(json_request)
         
@@ -246,7 +254,7 @@ def execute_sql(db_path, txn_handle, sql, arguments):
         raise Exception(f"Failed to rollback transaction on DB: {str(db_path)} : {str(e)}")
 
 
-def next_page(resultset_handle, resultset_pagination_size=None):
+def next_page(resultset_handle, resultset_pagination_size=None, data_format=None, include_metadata=None):
     try:
         json_request = {
             "request-type": "next",
@@ -254,6 +262,10 @@ def next_page(resultset_handle, resultset_pagination_size=None):
         }
         if resultset_pagination_size and resultset_pagination_size > 0:
             json_request["resultset-pagination-size"] = resultset_pagination_size
+        if data_format is not None:
+            json_request["resultset-data-format"] = data_format
+        if include_metadata is not None:
+            json_request["resultset-include-metadata"] = "ON" if include_metadata else "OFF"
 
         json_response = process_request(json_request)
         return _to_result(json_response)
@@ -328,14 +340,15 @@ if not r.result:
 print("=" * 56)
 
 
-# Select from table
+# Select from table (JSON format - default, records as {colName: colValue} dicts)
 print("=" * 56)
-print("Executing select from table")
+print("Executing select from table (JSON format)")
 print("=" * 56)
 r = execute_sql(db_path, None, "select a, b from t1", None)
 print(f"result : {r.result}")
 print(f"message : {r.message}")
-print("Selected Records: ")
+if r.column_metadata:
+    print("\t".join(col['label'] for col in r.column_metadata))
 current = r
 while True:
     if current.result_set:
@@ -344,6 +357,29 @@ while True:
     if not current.has_more or not current.resultset_handle:
         break
     current = next_page(current.resultset_handle)
+    if not current.result:
+        print(f"next failed: {current.message}")
+        sys.exit(1)
+print("=" * 56)
+
+
+# Select from table (DB format - records as value arrays, column order matches metadata)
+print("=" * 56)
+print("Executing select from table (DB format)")
+print("=" * 56)
+r = execute_sql(db_path, None, "select a, b from t1", None, data_format="DB", include_metadata=True)
+print(f"result : {r.result}")
+print(f"message : {r.message}")
+if r.column_metadata:
+    print("\t".join(col['label'] for col in r.column_metadata))
+current = r
+while True:
+    if current.result_set:
+        for row in current.result_set:
+            print("\t".join(str(v) if v is not None else "null" for v in row))
+    if not current.has_more or not current.resultset_handle:
+        break
+    current = next_page(current.resultset_handle, data_format="DB")
     if not current.result:
         print(f"next failed: {current.message}")
         sys.exit(1)

--- a/sdk-source/ruby/SyncLiteDBClient.rb
+++ b/sdk-source/ruby/SyncLiteDBClient.rb
@@ -77,7 +77,7 @@ sql: drop table t1
 =end
 
 class SyncLiteDBResult
-  attr_accessor :result, :message, :result_set, :txn_handle, :resultset_handle, :has_more
+  attr_accessor :result, :message, :result_set, :txn_handle, :resultset_handle, :has_more, :column_metadata
 
   def initialize
     @result_set = []
@@ -139,6 +139,7 @@ class SyncLiteDBClient
     result.txn_handle = json_response['txn-handle'] if json_response.key?('txn-handle')
     result.resultset_handle = json_response['resultset-handle'] if json_response.key?('resultset-handle')
     result.has_more = json_response['has-more'] if json_response.key?('has-more')
+    result.column_metadata = json_response['resultset-metadata'] if json_response.key?('resultset-metadata')
     result
   end
 
@@ -188,7 +189,7 @@ class SyncLiteDBClient
     to_db_result(json_response)
   end
 
-  def self.execute_sql(db_path, txn_handle, sql, arguments = nil)
+  def self.execute_sql(db_path, txn_handle, sql, arguments = nil, data_format: nil, include_metadata: nil)
     json_request = {
       'db-path' => db_path.to_s,
       'sql' => sql,
@@ -196,17 +197,21 @@ class SyncLiteDBClient
     }.compact
 
 	json_request['txn-handle'] = txn_handle.to_s unless txn_handle.nil?
+    json_request['resultset-data-format'] = data_format unless data_format.nil?
+    json_request['resultset-include-metadata'] = include_metadata ? 'ON' : 'OFF' unless include_metadata.nil?
 
     json_response = process_request(json_request)
     to_db_result(json_response)
   end
 
-  def self.next_page(resultset_handle, resultset_pagination_size = nil)
+  def self.next_page(resultset_handle, resultset_pagination_size = nil, data_format: nil, include_metadata: nil)
     json_request = {
       'request-type' => 'next',
       'resultset-handle' => resultset_handle
     }
     json_request['resultset-pagination-size'] = resultset_pagination_size if !resultset_pagination_size.nil? && resultset_pagination_size.to_i > 0
+    json_request['resultset-data-format'] = data_format unless data_format.nil?
+    json_request['resultset-include-metadata'] = include_metadata ? 'ON' : 'OFF' unless include_metadata.nil?
 
     json_response = process_request(json_request)
     to_db_result(json_response)
@@ -272,12 +277,14 @@ class SyncLiteDBClient
     exit(1) unless r.result
 
     puts "========================================================"
-    puts "Executing select from table"
+    puts "Executing select from table (JSON format)"
     puts "========================================================"
     r = execute_sql(db_path, nil, 'select a, b from t1')
     puts "result: #{r.result}, message: #{r.message}"
 
-    puts "Selected Records:"
+    if r.column_metadata
+      puts r.column_metadata.map { |c| c['label'] }.join("\t")
+    end
     current = r
     loop do
       current.result_set.each do |rec|
@@ -287,6 +294,27 @@ class SyncLiteDBClient
       break unless current.has_more && current.resultset_handle
 
       current = next_page(current.resultset_handle)
+      raise "Next page call failed: #{current.message}" unless current.result
+    end
+
+    puts "========================================================"
+    puts "Executing select from table (DB format)"
+    puts "========================================================"
+    r = execute_sql(db_path, nil, 'select a, b from t1', nil, data_format: 'DB', include_metadata: true)
+    puts "result: #{r.result}, message: #{r.message}"
+
+    if r.column_metadata
+      puts r.column_metadata.map { |c| c['label'] }.join("\t")
+    end
+    current = r
+    loop do
+      current.result_set.each do |row|
+        puts row.map { |v| v.nil? ? 'null' : v.to_s }.join("\t")
+      end
+
+      break unless current.has_more && current.resultset_handle
+
+      current = next_page(current.resultset_handle, nil, data_format: 'DB')
       raise "Next page call failed: #{current.message}" unless current.result
     end
 

--- a/sdk-source/rust/src/main.rs
+++ b/sdk-source/rust/src/main.rs
@@ -89,6 +89,7 @@ struct SyncLiteDBResult {
     txn_handle: Option<String>,
     resultset_handle: Option<String>,
     has_more: Option<bool>,
+    column_metadata: Option<Value>,
 }
 
 const SYNC_LITE_DB_ADDRESS: &str = "http://localhost:5555";
@@ -165,6 +166,7 @@ fn to_db_result(json_response: &Value) -> SyncLiteDBResult {
         txn_handle: json_response.get("txn-handle").and_then(Value::as_str).map(|s| s.to_string()),
         resultset_handle: json_response.get("resultset-handle").and_then(Value::as_str).map(|s| s.to_string()),
         has_more: json_response.get("has-more").and_then(Value::as_bool),
+        column_metadata: json_response.get("resultset-metadata").cloned(),
     }
 }
 
@@ -216,7 +218,7 @@ fn rollback_transaction(db_path: &Path, txn_handle: &str) -> Result<SyncLiteDBRe
     Ok(to_db_result(&json_response))
 }
 
-fn execute_sql(db_path: &Path, txn_handle: Option<&str>, sql: &str, arguments: Option<&Value>) -> Result<SyncLiteDBResult, String> {
+fn execute_sql(db_path: &Path, txn_handle: Option<&str>, sql: &str, arguments: Option<&Value>, data_format: Option<&str>, include_metadata: Option<bool>) -> Result<SyncLiteDBResult, String> {
     let mut json_request = json!({
         "db-path": db_path.to_str().unwrap(),
         "sql": sql,
@@ -228,13 +230,19 @@ fn execute_sql(db_path: &Path, txn_handle: Option<&str>, sql: &str, arguments: O
     if let Some(args) = arguments {
         json_request["arguments"] = args.clone();
     }
+    if let Some(fmt) = data_format {
+        json_request["resultset-data-format"] = json!(fmt);
+    }
+    if let Some(meta) = include_metadata {
+        json_request["resultset-include-metadata"] = json!(if meta { "ON" } else { "OFF" });
+    }
 
     let json_response = process_request(&json_request)?;
 
     Ok(to_db_result(&json_response))
 }
 
-fn next_page(resultset_handle: &str, resultset_pagination_size: Option<u64>) -> Result<SyncLiteDBResult, String> {
+fn next_page(resultset_handle: &str, resultset_pagination_size: Option<u64>, data_format: Option<&str>, include_metadata: Option<bool>) -> Result<SyncLiteDBResult, String> {
     let mut json_request = json!({
         "request-type": "next",
         "resultset-handle": resultset_handle,
@@ -244,6 +252,12 @@ fn next_page(resultset_handle: &str, resultset_pagination_size: Option<u64>) -> 
         if size > 0 {
             json_request["resultset-pagination-size"] = json!(size);
         }
+    }
+    if let Some(fmt) = data_format {
+        json_request["resultset-data-format"] = json!(fmt);
+    }
+    if let Some(meta) = include_metadata {
+        json_request["resultset-include-metadata"] = json!(if meta { "ON" } else { "OFF" });
     }
 
     let json_response = process_request(&json_request)?;
@@ -306,7 +320,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("========================================================");
     println!("Executing create table");
     println!("========================================================");
-    let r = execute_sql(&db_path, Some(txn_handle), "create table if not exists t1(a int, b text)", None).map_err(|e| format!("Error: {}", e))?;
+    let r = execute_sql(&db_path, Some(txn_handle), "create table if not exists t1(a int, b text)", None, None, None).map_err(|e| format!("Error: {}", e))?;
     println!("result : {}", r.result);
     println!("message : {}", r.message);
     if !r.result {
@@ -323,7 +337,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         [2, "two"],
     ]);
 
-    let r = execute_sql(&db_path, Some(txn_handle), "insert into t1 (a, b) values(?, ?)", Some(&arguments)).map_err(|e| format!("Error: {}", e))?;
+    let r = execute_sql(&db_path, Some(txn_handle), "insert into t1 (a, b) values(?, ?)", Some(&arguments), None, None).map_err(|e| format!("Error: {}", e))?;
     println!("result : {}", r.result);
     println!("message : {}", r.message);
     if !r.result {
@@ -343,15 +357,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     println!("========================================================");
 
-    // Select from table
+    // Select from table (JSON format - default, records as {colName: colValue} objects)
     println!("========================================================");
-    println!("Executing select from table");
+    println!("Executing select from table (JSON format)");
     println!("========================================================");
-    let r = execute_sql(&db_path, None, "select a, b from t1", None).map_err(|e| format!("Error: {}", e))?;
+    let r = execute_sql(&db_path, None, "select a, b from t1", None, None, None).map_err(|e| format!("Error: {}", e))?;
     println!("result : {}", r.result);
     println!("message : {}", r.message);
 
-    println!("Selected Records:");
+    if let Some(meta) = &r.column_metadata {
+        if let Some(cols) = meta.as_array() {
+            let headers: Vec<&str> = cols.iter().filter_map(|c| c["label"].as_str()).collect();
+            println!("{}", headers.join("\t"));
+        }
+    }
     let mut current = r;
     loop {
         if let Some(result_set) = &current.result_set {
@@ -371,18 +390,60 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         let next_handle = handle.unwrap();
-        current = next_page(&next_handle, None).map_err(|e| format!("Error: {}", e))?;
+        current = next_page(&next_handle, None, None, None).map_err(|e| format!("Error: {}", e))?;
         if !current.result {
             return Err(format!("Next page call failed: {}", current.message).into());
         }
     }
     println!("========================================================");
 
+    // Select from table (DB format - records as value arrays, column order matches column_metadata)
+    println!("========================================================");
+    println!("Executing select from table (DB format)");
+    println!("========================================================");
+    let r = execute_sql(&db_path, None, "select a, b from t1", None, Some("DB"), Some(true)).map_err(|e| format!("Error: {}", e))?;
+    println!("result : {}", r.result);
+    println!("message : {}", r.message);
+
+    if let Some(meta) = &r.column_metadata {
+        if let Some(cols) = meta.as_array() {
+            let headers: Vec<&str> = cols.iter().filter_map(|c| c["label"].as_str()).collect();
+            println!("{}", headers.join("\t"));
+        }
+    }
+    let mut current = r;
+    loop {
+        if let Some(result_set) = &current.result_set {
+            if let Some(array) = result_set.as_array() {
+                for row in array {
+                    if let Some(values) = row.as_array() {
+                        let vals: Vec<String> = values.iter().map(|v| {
+                            if v.is_null() { "null".to_string() } else { v.to_string() }
+                        }).collect();
+                        println!("{}", vals.join("\t"));
+                    }
+                }
+            }
+        }
+
+        let has_more = current.has_more.unwrap_or(false);
+        let handle = current.resultset_handle.clone();
+        if !has_more || handle.is_none() {
+            break;
+        }
+
+        let next_handle = handle.unwrap();
+        current = next_page(&next_handle, None, Some("DB"), None).map_err(|e| format!("Error: {}", e))?;
+        if !current.result {
+            return Err(format!("Next page call failed: {}", current.message).into());
+        }
+    }
+
     // Drop table
     println!("========================================================");
     println!("Executing drop table");
     println!("========================================================");
-    let r = execute_sql(&db_path, None, "drop table t1", None).map_err(|e| format!("Error: {}", e))?;
+    let r = execute_sql(&db_path, None, "drop table t1", None, None, None).map_err(|e| format!("Error: {}", e))?;
     println!("result : {}", r.result);
     println!("message : {}", r.message);
 


### PR DESCRIPTION
# Add resultset data-format and metadata controls, propagate through server, tests, and SDK source samples

## Summary
This PR adds configurable SELECT result serialization and metadata emission, then applies the protocol updates across checked-out server files, integration tests, and SDK sample clients.

New request options:
- resultset-data-format: JSON (default) or DB
- resultset-include-metadata: ON (default) or OFF

New response field:
- resultset-metadata

## Changes By Checked-Out File

### Server files

1) db/src/main/java/com/synclite/db/RequestProcessor.java
- Parses and validates resultset-data-format and resultset-include-metadata
- Applies options for both initial SELECT execution and next page requests
- Adds row formatting branch:
  - JSON format: row objects by column label
  - DB format: positional row arrays
- Sends resultset-metadata conditionally based on include flag

2) db/src/main/java/com/synclite/db/DB.java
- Extracts JDBC column metadata into a resultset-metadata array
- Preserves deterministic column order using LinkedHashMap
- Stores metadata in paged resultset state so metadata remains available across next calls

3) db/src/main/java/com/synclite/db/Main.java
- Extends createJsonResponseWithHandle with metadata-aware overload
- Adds optional resultset-metadata in response payload

### Test files

4) db/src/test/java/sampleapp/SyncLiteDBClient.java
- Extends test client result model with resultsetHandle, hasMore, and columnMetadata
- Adds executeSQL overload and next method with data-format and include-metadata options
- Centralizes response parsing for pagination and metadata fields

5) db/src/test/java/com/synclite/db/SyncLiteDBIntegrationTest.java
- Adds testResultsetDataFormatAndMetadata
- Verifies JSON format rows and DB format rows
- Verifies metadata ON/OFF behavior on both first page and next page
- Keeps existing auth and pagination coverage intact

### SDK source sample files

6) sdk-source/java/SyncLiteDBClient.java
- Adds columnMetadata field and metadata parsing
- Adds executeSQL and next overloads for data format and metadata options
- Updates sample flow to demonstrate JSON and DB modes

7) sdk-source/python/SyncLiteDBClient.py
- Adds column_metadata to result object
- Adds optional data_format/include_metadata parameters
- Updates sample flow for JSON and DB modes

8) sdk-source/node.js/SyncLiteDBClient.js
- Adds columnMetadata parsing
- Adds optional dataFormat/includeMetadata parameters for executeSQL and next
- Renames local insert variable to avoid reserved-word conflict
- Updates sample flow for JSON and DB modes

9) sdk-source/go/SyncLiteDBClient.go
- Adds ColumnMetadata to result struct
- Adds dataFormat/includeMetadata support on executeSQL and next
- Updates sample flow for JSON and DB modes

10) sdk-source/c#/SyncLiteDBClient.cs
- Adds ColumnMetadata to result model and parser
- Adds optional dataFormat/includeMetadata parameters on ExecuteSQL and Next
- Updates sample output flow for JSON and DB modes

11) sdk-source/cpp/SyncLiteDBClient.cpp
- Adds columnMetadata parsing in result model
- Adds executeSQL/next overloads for dataFormat/includeMetadata
- Updates sample flow for JSON and DB modes

12) sdk-source/ruby/SyncLiteDBClient.rb
- Adds column_metadata to result model
- Adds data_format/include_metadata keyword options for execute_sql and next_page
- Updates sample flow for JSON and DB modes

13) sdk-source/rust/src/main.rs
- Adds column_metadata field to result model
- Adds data_format/include_metadata options to execute_sql and next_page
- Updates sample flow for JSON and DB modes

### Generated artifact currently checked out

## Validation
Executed:
- mvn -q -Drevision=oss -Dtest=SyncLiteDBIntegrationTest test

Observed:
- Tests run: 3
- Failures: 0
- Errors: 0
- Skipped: 0

## Compatibility
- Existing clients remain compatible via default behavior (JSON + metadata ON)
- New clients can request DB row-array format and disable metadata per request/page
