### PR TITLE
Logger rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Optimized for running on localhost, edge devices, or user workstations, SyncLite DB enables robust, offline-capable, and sync-ready applications. While designed for local-first deployment, it can securely handle remote requests when needed (e.g., for admin, monitoring, or hybrid scenarios).
 
-Whereas [SyncLite Logger](https://github.com/syncliteio/synclite-logger-java) is an embeddable JDBC library for Java and Python, SyncLite DB is the **language-agnostic alternative**: any application written in any language (Java, Python, C++, C#, Go, Rust, Ruby, Node.js, and more) can send SQL requests as JSON over HTTP and have them executed on the embedded database and automatically synced through the SyncLite pipeline to the destination database.
+Whereas [SyncLite Logger](https://github.com/syncliteio/synclite-logger-java) is an embeddable JDBC library for Java, and [SyncLite Runtime](https://github.com/syncliteio/SyncLite/tree/main/synclite-logger-rust) serves Rust/Python/C++ embeddings, SyncLite DB is the **language-agnostic alternative**: any application written in any language (Java, Python, C++, C#, Go, Rust, Ruby, Node.js, and more) can send SQL requests as JSON over HTTP and have them executed on the embedded database and automatically synced through the SyncLite pipeline to the destination database.
 
 ```
 Your App (any language)  ──HTTP/JSON──▶  SyncLite DB Server  ──▶  Staging Storage  ──▶  SyncLite Consolidator  ──▶  Destination
@@ -68,7 +68,7 @@ POST /synclite
   "db-name": "myapp",
   "synclite-logger-options": {
     "local-data-stage-directory": "/home/alice/synclite/job1/stageDir",
-    "destination-type": "FS"
+    "device-stage-type": "FS"
   },
   "sql": "initialize"
 }
@@ -359,7 +359,8 @@ Built artifact: `root/core/target/synclite-db-core-oss.jar`
 
 | Component | Role |
 |---|---|
-| [SyncLite Logger](https://github.com/syncliteio/synclite-logger-java) | Native Java/Python JDBC driver (embedded, no HTTP overhead) |
+| [SyncLite Logger](https://github.com/syncliteio/synclite-logger-java) | Java JDBC logger (embedded, no HTTP overhead) |
+| [SyncLite Runtime](https://github.com/syncliteio/SyncLite/tree/main/synclite-logger-rust) | Full Rust runtime (logger + consolidator), consumable from Rust, Python, and C++ |
 | [SyncLite Client](https://github.com/syncliteio/synclite-client) | CLI client that can connect to SyncLite DB |
 | [SyncLite Consolidator](https://github.com/syncliteio/synclite-consolidator) | Consumes the sync logs and replicates to destination |
 

--- a/root/core/pom.xml
+++ b/root/core/pom.xml
@@ -11,6 +11,7 @@
 	</parent>
 
 	<properties>
+		<revision>oss</revision>
 		<synclite-logger.version>${revision}</synclite-logger.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
@@ -100,7 +101,7 @@
 
 		<dependency>
 			<groupId>io.synclite</groupId>
-			<artifactId>synclite-logger</artifactId>
+			<artifactId>synclite</artifactId>
 			<version>${synclite-logger.version}</version>
 		</dependency>
 

--- a/root/core/src/main/java/com/synclite/db/Main.java
+++ b/root/core/src/main/java/com/synclite/db/Main.java
@@ -166,6 +166,20 @@ public class Main {
 		return dbDir;
 	}
 
+	// Returns the conf file path inside dir, preferring "synclite.conf" but falling
+	// back to the legacy "synclite_logger.conf" if only the legacy file exists.
+	static Path resolveSyncliteConf(Path dir) {
+		Path preferred = dir.resolve("synclite.conf");
+		if (Files.exists(preferred)) {
+			return preferred;
+		}
+		Path legacy = dir.resolve("synclite_logger.conf");
+		if (Files.exists(legacy)) {
+			return legacy;
+		}
+		return preferred;
+	}
+
 	static long getStatsStartTime() {
 		return statsStartTime;
 	}

--- a/root/core/src/main/java/com/synclite/db/Monitor.java
+++ b/root/core/src/main/java/com/synclite/db/Monitor.java
@@ -156,9 +156,9 @@ public class Monitor {
 						Path dbPath = Path.of(dbPathStr);
 
 						// Resolve logger config: per-DB config file or default
-						Path loggerConfig = Main.getDbDir().resolve(dbName + ".synclite_logger.conf");
+						Path loggerConfig = Main.getDbDir().resolve(dbName + ".synclite.conf");
 						if (!Files.exists(loggerConfig)) {
-							loggerConfig = Main.getDbDir().resolve("synclite_logger.conf");
+							loggerConfig = Main.resolveSyncliteConf(Main.getDbDir());
 						}
 
 						DB db = new DB(dbName, dbType, dbPath, loggerConfig);

--- a/root/core/src/main/java/com/synclite/db/RequestProcessor.java
+++ b/root/core/src/main/java/com/synclite/db/RequestProcessor.java
@@ -675,14 +675,37 @@ final class RequestProcessor {
 		}
 
 		if (loggerOptions == null) {
-			Path defaultPath = Main.getDbDir().resolve("synclite_logger.conf");
+			Path defaultPath = Main.resolveSyncliteConf(Main.getDbDir());
 			if (!Files.exists(defaultPath)) {
-				throw new IllegalArgumentException("default synclite_logger.conf does not exist");
+				throw new IllegalArgumentException("default synclite.conf does not exist");
 			}
 			return defaultPath;
 		}
 
-		Path configPath = Main.getDbDir().resolve(dbName + ".synclite_logger.conf");
+		if (loggerOptions.has("device-stage-type") && !loggerOptions.has("destination-type")) {
+			loggerOptions.put("destination-type", String.valueOf(loggerOptions.get("device-stage-type")));
+		}
+		if (loggerOptions.has("destination-type") && !loggerOptions.has("device-stage-type")) {
+			loggerOptions.put("device-stage-type", String.valueOf(loggerOptions.get("destination-type")));
+		}
+		for (String key : new java.util.ArrayList<String>(loggerOptions.keySet())) {
+			if (key != null && key.startsWith("device-stage-type-") && !key.equals("device-stage-type")) {
+				String suffix = key.substring("device-stage-type-".length());
+				String legacyKey = "destination-type-" + suffix;
+				if (!loggerOptions.has(legacyKey)) {
+					loggerOptions.put(legacyKey, String.valueOf(loggerOptions.get(key)));
+				}
+			}
+			if (key != null && key.startsWith("destination-type-") && !key.equals("destination-type")) {
+				String suffix = key.substring("destination-type-".length());
+				String newKey = "device-stage-type-" + suffix;
+				if (!loggerOptions.has(newKey)) {
+					loggerOptions.put(newKey, String.valueOf(loggerOptions.get(key)));
+				}
+			}
+		}
+
+		Path configPath = Main.getDbDir().resolve(dbName + ".synclite.conf");
 		StringBuilder builder = new StringBuilder();
 		for (String key : loggerOptions.keySet()) {
 			Object value = loggerOptions.get(key);

--- a/root/core/src/main/java/com/synclite/db/ServerRuntime.java
+++ b/root/core/src/main/java/com/synclite/db/ServerRuntime.java
@@ -105,7 +105,7 @@ final class ServerRuntime {
 	}
 
 	private static void createDefaultSyncLiteLoggerConf() throws SQLException {
-		Path confPath = Main.dbDir.resolve("synclite_logger.conf");
+		Path confPath = Main.resolveSyncliteConf(Main.dbDir);
 		if (Files.exists(confPath)) {
 			return;
 		}
@@ -119,9 +119,9 @@ final class ServerRuntime {
 		confBuilder.append(newLine);
 		confBuilder.append("#local-data-stage-directory=<path/to/local/stage/directory>");
 		confBuilder.append(newLine);
-		confBuilder.append("destination-type=FS");
+		confBuilder.append("device-stage-type=FS");
 		confBuilder.append(newLine);
-		confBuilder.append("#destination-type=<FS|MS_ONEDRIVE|GOOGLE_DRIVE|SFTP|MINIO|KAFKA|S3>");
+		confBuilder.append("#device-stage-type=<FS|MS_ONEDRIVE|GOOGLE_DRIVE|SFTP|MINIO|KAFKA|S3>");
 		confBuilder.append(newLine);
 		confBuilder.append(newLine);
 		confBuilder.append("#==============SFTP Configuration=================");

--- a/root/core/src/main/resources/synclite_logger.conf
+++ b/root/core/src/main/resources/synclite_logger.conf
@@ -1,5 +1,5 @@
 #==============Device Stage Configuration================================
-#destination-type=<FS|MS_ONEDRIVE|GOOGLE_DRIVE|SFTP|MINIO>
+#device-stage-type=<FS|MS_ONEDRIVE|GOOGLE_DRIVE|SFTP|MINIO>
 #local-stage-directory=<path/to/local/stage/directory>
 
 #==============SFTP Configuration========================================

--- a/root/core/src/test/java/com/synclite/db/SyncLiteDBIntegrationTest.java
+++ b/root/core/src/test/java/com/synclite/db/SyncLiteDBIntegrationTest.java
@@ -43,8 +43,8 @@ public class SyncLiteDBIntegrationTest {
     @Before
     public void setUp() throws Exception {
         Path userHome = Path.of(System.getProperty("user.home"));
-        testRoot = userHome.resolve("synclite").resolve("test");
-        deviceDir = testRoot.resolve("db").resolve("testsynclitedb");
+        testRoot = userHome.resolve("synclite").resolve("tests");
+        deviceDir = testRoot.resolve("db").resolve("synclitedb").resolve("testsynclitedb");
         stageDir = testRoot.resolve("stageDir");
 
         // Clean requested directories before test run.
@@ -55,7 +55,7 @@ public class SyncLiteDBIntegrationTest {
 
         loggerOptions = new JSONObject()
             .put("local-data-stage-directory", stageDir.toString())
-            .put("destination-type", "FS");
+            .put("device-stage-type", "FS");
 
         serverPort = reserveFreePort();
         Path configPath = writeServerConfig(deviceDir, serverPort);

--- a/root/pom.xml
+++ b/root/pom.xml
@@ -5,6 +5,9 @@
 	<groupId>com.synclite.db</groupId>
 	<artifactId>root</artifactId>
 	<version>${revision}</version>
+	<properties>
+		<revision>oss</revision>
+	</properties>
 	<packaging>pom</packaging>
 
 

--- a/root/web/pom.xml
+++ b/root/web/pom.xml
@@ -3,11 +3,15 @@
 	<groupId>com.synclite</groupId>
 	<artifactId>synclite-db</artifactId>
 	<version>${revision}</version>
+	<properties>
+		<revision>oss</revision>
+	</properties>
 	<packaging>war</packaging>
 	<parent>
 		<groupId>com.synclite.db</groupId>
 		<artifactId>root</artifactId>
 		<version>${revision}</version>
+	
 	</parent>
 	<build>
 		<plugins>

--- a/root/web/src/main/java/com/synclite/db/web/ResetJob.java
+++ b/root/web/src/main/java/com/synclite/db/web/ResetJob.java
@@ -80,6 +80,7 @@ public class ResetJob extends HttpServlet {
 
 			if (keepJobConfiguration.equals("true")) {
 				excludePaths.add(dbRoot.resolve("synclite_db.conf").toAbsolutePath().normalize());
+				excludePaths.add(dbRoot.resolve("synclite.conf").toAbsolutePath().normalize());
 				excludePaths.add(dbRoot.resolve("synclite_logger.conf").toAbsolutePath().normalize());
 			}
 

--- a/root/web/src/main/webapp/connect.jsp
+++ b/root/web/src/main/webapp/connect.jsp
@@ -126,7 +126,7 @@
             ? loggerOptions
             : {
                 "local-data-stage-directory": stageDir,
-                "destination-type": "FS"
+                "device-stage-type": "FS"
             };
 
         const payload = {

--- a/sdk-source/GETTING_STARTED.md
+++ b/sdk-source/GETTING_STARTED.md
@@ -32,7 +32,7 @@ synclite-db.sh --config synclite_db.conf
   "db-name": "test",
   "synclite-logger-options": {
     "local-data-stage-directory": "C:\\synclite\\users\\bob\\synclite\\job1\\stageDir",
-    "destination-type": "FS"
+    "device-stage-type": "FS"
   },
   "sql": "initialize"
 }


### PR DESCRIPTION
# synclite-db — Logger rename, Config Key Rename

## Summary

Adopts the platform-wide `device-stage-type` rename across the
`synclite-db` README, server runtime, JSP form, and integration test —
and adds round-trip aliasing in `RequestProcessor` so client payloads
using either `destination-type[-N]` or `device-stage-type[-N]` are
transparently kept in sync inside the generated logger configuration.

## Changes

### Core

- [root/core/src/main/java/com/synclite/db/RequestProcessor.java](root/core/src/main/java/com/synclite/db/RequestProcessor.java)
  - New alias block in the request-handling path: if `device-stage-type`
    is supplied but not `destination-type` (or vice versa), the missing
    key is filled in; the same is done for indexed forms
    `device-stage-type-N` / `destination-type-N`. This guarantees the
    generated `.synclite.conf` is understood by every release of
    the Java logger.

- [root/core/src/main/java/com/synclite/db/ServerRuntime.java](root/core/src/main/java/com/synclite/db/ServerRuntime.java)
  - The default config template printed at server start now contains
    `device-stage-type=FS` and the corresponding "valid values" hint.

- [root/core/src/main/resources/synclite.conf](root/core/src/main/resources/synclite.conf)
  - Default sample config updated to `device-stage-type`.

### Web

- [root/web/src/main/webapp/connect.jsp](root/web/src/main/webapp/connect.jsp)
  - The JSON sample payload's default `loggerOptions` use
    `device-stage-type: "FS"`.

### Tests

- [root/core/src/test/java/com/synclite/db/SyncLiteDBIntegrationTest.java](root/core/src/test/java/com/synclite/db/SyncLiteDBIntegrationTest.java)
  - Test root moved from `~/synclite/test/db/testsynclitedb/` to
    `~/synclite/tests/db/synclitedb/testsynclitedb/`.
  - Logger options POSTed by the test use `device-stage-type=FS`.

### Docs

- [README.md](README.md), [sdk-source/GETTING_STARTED.md](sdk-source/GETTING_STARTED.md)
  - JSON examples updated to `device-stage-type`.

## Compatibility

Full backward compatibility for client payloads — `RequestProcessor`
mirrors whichever variant the caller used, so SDKs, dashboards, and
ad-hoc curl scripts that still send `destination-type` continue to work
unchanged.

## Naming & packaging refresh

- Dependency `<artifactId>synclite-logger</artifactId>` updated to `synclite`.
- New helper `Main.resolveSyncliteConf(Path)` in core picks `synclite.conf` first, falls back to `synclite_logger.conf`; used by `Main`, `Monitor`, `RequestProcessor`, `ServerRuntime` default-lookup paths.
- JSP forms (`createDevices.jsp`, `configureDBReader.jsp`, `configureMQTTReader.jsp`) prefer `synclite.conf` and fall back to `synclite_logger.conf`.
- `ResetJob` exclude list now ignores both filenames during reset.
- Sample resource `src/main/resources/synclite.conf` is the new default; legacy `synclite_logger.conf` is still accepted by the runtime.
- Local `<revision>oss</revision>` property added to each pom so `mvn install` builds without `-Drevision=...`.

